### PR TITLE
Add organizer page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 public/
+/resources/_gen/
 *.lock

--- a/assets/organizers.json
+++ b/assets/organizers.json
@@ -1,0 +1,16 @@
+{
+    "General": [],
+    "Program": [],
+    "SpecialSession": [],
+    "DemoAndExhibition": [],
+    "Publication": [],
+    "Competition": [],
+    "WorkshopsTutorials": [],
+    "Publicity": [],
+    "Website": [],
+    "FinanceAndLocal": [],
+    "Awards": [],
+    "Sponsorship": [],
+    "DoctoralConsortium": [],
+    "organizers": []
+}

--- a/assets/styles/layouts/organizers/organizer-card.css
+++ b/assets/styles/layouts/organizers/organizer-card.css
@@ -1,0 +1,89 @@
+.organizer-card {
+    width: 16.875rem;
+    height: 15.9375rem;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-between;
+    border-radius: 0.3125rem;
+    border: 0.0625rem solid var(--color-primary);
+    box-shadow:
+        0 0 0 0 var(--color-primary),
+        0 0.0625rem 0.1875rem var(--color-shadow);
+    transition: box-shadow 0.3s ease;
+}
+
+.organizer-card:hover {
+    box-shadow:
+        0 0 0 0.1875rem var(--color-primary),
+        0 0.0625rem 0.1875rem var(--color-shadow);
+}
+
+.organizer-card__link {
+    all: unset;
+    box-sizing: border-box;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    align-items: center;
+    gap: 1.25rem;
+    padding: 1.5625rem 1.625rem 0 1.625rem;
+    cursor: pointer;
+}
+
+.organizer-card__avatar {
+    border-radius: 50%;
+    width: 7.5rem;
+    height: 7.5rem;
+}
+
+.organizer-card__description {
+    all: unset;
+    font-size: 1rem;
+    height: 2.75rem;
+    line-height: 1.375rem;
+    font-weight: 400;
+    text-align: center;
+    color: var(--color-secondary-darker);
+    display: block;
+    text-overflow: ellipsis;
+    word-wrap: break-word;
+    overflow: hidden;
+}
+
+.organizer-card__social-links {
+    flex-shrink: 1;
+    margin-bottom: 0.9375rem;
+}
+
+.organizer-card__social-link {
+    color: var(--color-primary);
+    font-size: 1.125rem;
+    padding: 0.25rem;
+    opacity: 0.5;
+    transition: border 0.3s ease;
+    position: relative;
+}
+
+.organizer-card__social-link::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    opacity: 1;
+    z-index: -1;
+    transition: border 0.3s ease;
+}
+
+.organizer-card__social-link:hover::before {
+    background-color: var(--color-primary-lighter);
+    opacity: 0.2;
+}
+
+.organizer-card__social-link:hover {
+    opacity: 1;
+}

--- a/content/organizers/_content.gotmpl
+++ b/content/organizers/_content.gotmpl
@@ -1,0 +1,19 @@
+{{ .EnableAllLanguages }}
+
+{{ $context := . }}
+
+{{ with partial "organizers-all.html" }}
+
+    {{ with partial "content-adapters/create-organizers-content.html" (
+        dict
+        "sessionize" .
+        )
+    }}
+        {{ range .pages }}
+            {{ $.AddPage . }}
+        {{ end }}
+        {{ range .resources }}
+            {{ $.AddResource . }}
+        {{ end }}
+    {{ end }}
+{{ end }}

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -6,6 +6,11 @@ languages:
     _merge: deep
     en:
         disabled: false
+        menu:
+          main:
+            - identifier: organizers
+              pageRef: /organizers
+              weight: 10
 
 params:
     themes:

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,0 +1,1 @@
+organizers_page.heading: Organizers

--- a/layouts/organizers/list.html
+++ b/layouts/organizers/list.html
@@ -1,0 +1,336 @@
+{{ define "main" }}
+    <section class="speaker-list">
+        <div class="section">
+            {{ $pages := .Pages }}
+            {{ with $data := partial "organizers-all.html" }}
+                {{ $itemMap := dict }}
+                {{ range $item := $data.organizers }}
+                    {{ $itemMap = merge $itemMap (dict $item.id $item) }}
+                {{ end }}
+                {{ $pageMap := dict }}
+                {{ range $item := $pages }}
+                    {{ $pageMap = merge $pageMap (dict $item.Params.organizerId $item) }}
+                {{ end }}
+
+                <!-- <h1 class="heading heading--1">{{ T "organizers_page.heading" }}</h1> -->
+                <h1 class="heading heading--3">General Chairs</h1>
+                <menu class="speaker-list__menu">
+                {{ range $id := $data.General }}
+                    {{ $organizer := index $itemMap $id }}
+                    {{ $orgPage := index $pageMap $id }}
+                    {{ if $organizer }}
+                        <li class="speaker-list__item">
+                            {{- partial "organizer-card.html" (
+                                dict
+                                "profileUrl" $orgPage.RelPermalink
+                                "avatarResource" ($orgPage.Resources.GetMatch "avatar.*")
+                                "name" $orgPage.Title
+                                "description" $orgPage.Params.tagLine
+                                "linkedinUrl" $orgPage.Params.linkedinUrl
+                                "xUrl" $orgPage.Params.xUrl
+                                "companyUrl" $orgPage.Params.company
+                                )
+                            }}
+                        </li>
+                    {{ end }}
+                {{ end }}
+                </menu>
+                </br>
+                </br>
+                <h1 class="heading heading--3">Program Chairs</h1>
+                <menu class="speaker-list__menu">
+                {{ range $id := $data.Program }}
+                    {{ $organizer := index $itemMap $id }}
+                    {{ $orgPage := index $pageMap $id }}
+                    {{ if $organizer }}
+                        <li class="speaker-list__item">
+                            {{- partial "organizer-card.html" (
+                                dict
+                                "profileUrl" $orgPage.RelPermalink
+                                "avatarResource" ($orgPage.Resources.GetMatch "avatar.*")
+                                "name" $orgPage.Title
+                                "description" $orgPage.Params.tagLine
+                                "linkedinUrl" $orgPage.Params.linkedinUrl
+                                "xUrl" $orgPage.Params.xUrl
+                                "companyUrl" $orgPage.Params.company
+                                )
+                            }}
+                        </li>
+                    {{ end }}
+                {{ end }}
+                </menu>
+                </br>
+                </br>
+                <h1 class="heading heading--3">Special Session Chairs</h1>
+                <menu class="speaker-list__menu">
+                {{ range $id := $data.SpecialSession }}
+                    {{ $organizer := index $itemMap $id }}
+                    {{ $orgPage := index $pageMap $id }}
+                    {{ if $organizer }}
+                        <li class="speaker-list__item">
+                            {{- partial "organizer-card.html" (
+                                dict
+                                "profileUrl" $orgPage.RelPermalink
+                                "avatarResource" ($orgPage.Resources.GetMatch "avatar.*")
+                                "name" $orgPage.Title
+                                "description" $orgPage.Params.tagLine
+                                "linkedinUrl" $orgPage.Params.linkedinUrl
+                                "xUrl" $orgPage.Params.xUrl
+                                "companyUrl" $orgPage.Params.company
+                                )
+                            }}
+                        </li>
+                    {{ end }}
+                {{ end }}
+                </menu>
+                </br>
+                </br>
+                <h1 class="heading heading--3">Demo and Exhibition Chairs</h1>
+                <menu class="speaker-list__menu">
+                {{ range $id := $data.DemoAndExhibition }}
+                    {{ $organizer := index $itemMap $id }}
+                    {{ $orgPage := index $pageMap $id }}
+                    {{ if $organizer }}
+                        <li class="speaker-list__item">
+                            {{- partial "organizer-card.html" (
+                                dict
+                                "profileUrl" $orgPage.RelPermalink
+                                "avatarResource" ($orgPage.Resources.GetMatch "avatar.*")
+                                "name" $orgPage.Title
+                                "description" $orgPage.Params.tagLine
+                                "linkedinUrl" $orgPage.Params.linkedinUrl
+                                "xUrl" $orgPage.Params.xUrl
+                                "companyUrl" $orgPage.Params.company
+                                )
+                            }}
+                        </li>
+                    {{ end }}
+                {{ end }}
+                </menu>
+                </br>
+                </br>
+                <h1 class="heading heading--3">Publication Chairs</h1>
+                <menu class="speaker-list__menu">
+                {{ range $id := $data.Publication }}
+                    {{ $organizer := index $itemMap $id }}
+                    {{ $orgPage := index $pageMap $id }}
+                    {{ if $organizer }}
+                        <li class="speaker-list__item">
+                            {{- partial "organizer-card.html" (
+                                dict
+                                "profileUrl" $orgPage.RelPermalink
+                                "avatarResource" ($orgPage.Resources.GetMatch "avatar.*")
+                                "name" $orgPage.Title
+                                "description" $orgPage.Params.tagLine
+                                "linkedinUrl" $orgPage.Params.linkedinUrl
+                                "xUrl" $orgPage.Params.xUrl
+                                "companyUrl" $orgPage.Params.company
+                                )
+                            }}
+                        </li>
+                    {{ end }}
+                {{ end }}
+                </menu>
+                </br>
+                </br>
+                <h1 class="heading heading--3">Competition Chairs</h1>
+                <menu class="speaker-list__menu">
+                {{ range $id := $data.Competition }}
+                    {{ $organizer := index $itemMap $id }}
+                    {{ $orgPage := index $pageMap $id }}
+                    {{ if $organizer }}
+                        <li class="speaker-list__item">
+                            {{- partial "organizer-card.html" (
+                                dict
+                                "profileUrl" $orgPage.RelPermalink
+                                "avatarResource" ($orgPage.Resources.GetMatch "avatar.*")
+                                "name" $orgPage.Title
+                                "description" $orgPage.Params.tagLine
+                                "linkedinUrl" $orgPage.Params.linkedinUrl
+                                "xUrl" $orgPage.Params.xUrl
+                                "companyUrl" $orgPage.Params.company
+                                )
+                            }}
+                        </li>
+                    {{ end }}
+                {{ end }}
+                </menu>
+                </br>
+                </br>
+                <h1 class="heading heading--3">Workshops / Tutorials Chairs</h1>
+                <menu class="speaker-list__menu">
+                {{ range $id := $data.WorkshopsTutorials }}
+                    {{ $organizer := index $itemMap $id }}
+                    {{ $orgPage := index $pageMap $id }}
+                    {{ if $organizer }}
+                        <li class="speaker-list__item">
+                            {{- partial "organizer-card.html" (
+                                dict
+                                "profileUrl" $orgPage.RelPermalink
+                                "avatarResource" ($orgPage.Resources.GetMatch "avatar.*")
+                                "name" $orgPage.Title
+                                "description" $orgPage.Params.tagLine
+                                "linkedinUrl" $orgPage.Params.linkedinUrl
+                                "xUrl" $orgPage.Params.xUrl
+                                "companyUrl" $orgPage.Params.company
+                                )
+                            }}
+                        </li>
+                    {{ end }}
+                {{ end }}
+                </menu>
+                </br>
+                </br>
+                <h1 class="heading heading--3">Publicity Chairs</h1>
+                <menu class="speaker-list__menu">
+                {{ range $id := $data.Publicity }}
+                    {{ $organizer := index $itemMap $id }}
+                    {{ $orgPage := index $pageMap $id }}
+                    {{ if $organizer }}
+                        <li class="speaker-list__item">
+                            {{- partial "organizer-card.html" (
+                                dict
+                                "profileUrl" $orgPage.RelPermalink
+                                "avatarResource" ($orgPage.Resources.GetMatch "avatar.*")
+                                "name" $orgPage.Title
+                                "description" $orgPage.Params.tagLine
+                                "linkedinUrl" $orgPage.Params.linkedinUrl
+                                "xUrl" $orgPage.Params.xUrl
+                                "companyUrl" $orgPage.Params.company
+                                )
+                            }}
+                        </li>
+                    {{ end }}
+                {{ end }}
+                </menu>
+                </br>
+                </br>
+                <h1 class="heading heading--3">Website Chairs</h1>
+                <menu class="speaker-list__menu">
+                {{ range $id := $data.Website }}
+                    {{ $organizer := index $itemMap $id }}
+                    {{ $orgPage := index $pageMap $id }}
+                    {{ if $organizer }}
+                        <li class="speaker-list__item">
+                            {{- partial "organizer-card.html" (
+                                dict
+                                "profileUrl" $orgPage.RelPermalink
+                                "avatarResource" ($orgPage.Resources.GetMatch "avatar.*")
+                                "name" $orgPage.Title
+                                "description" $orgPage.Params.tagLine
+                                "linkedinUrl" $orgPage.Params.linkedinUrl
+                                "xUrl" $orgPage.Params.xUrl
+                                "companyUrl" $orgPage.Params.company
+                                )
+                            }}
+                        </li>
+                    {{ end }}
+                {{ end }}
+                </menu>
+                </br>
+                </br>
+                <h1 class="heading heading--3">Finance and Local Chairs</h1>
+                <menu class="speaker-list__menu">
+                {{ range $id := $data.FinanceAndLocal }}
+                    {{ $organizer := index $itemMap $id }}
+                    {{ $orgPage := index $pageMap $id }}
+                    {{ if $organizer }}
+                        <li class="speaker-list__item">
+                            {{- partial "organizer-card.html" (
+                                dict
+                                "profileUrl" $orgPage.RelPermalink
+                                "avatarResource" ($orgPage.Resources.GetMatch "avatar.*")
+                                "name" $orgPage.Title
+                                "description" $orgPage.Params.tagLine
+                                "linkedinUrl" $orgPage.Params.linkedinUrl
+                                "xUrl" $orgPage.Params.xUrl
+                                "companyUrl" $orgPage.Params.company
+                                )
+                            }}
+                        </li>
+                    {{ end }}
+                {{ end }}
+                </menu>
+                </br>
+                </br>
+                <h1 class="heading heading--3">Awards Chairs</h1>
+                <menu class="speaker-list__menu">
+                {{ range $id := $data.Awards }}
+                    {{ $organizer := index $itemMap $id }}
+                    {{ $orgPage := index $pageMap $id }}
+                    {{ if $organizer }}
+                        <li class="speaker-list__item">
+                            {{- partial "organizer-card.html" (
+                                dict
+                                "profileUrl" $orgPage.RelPermalink
+                                "avatarResource" ($orgPage.Resources.GetMatch "avatar.*")
+                                "name" $orgPage.Title
+                                "description" $orgPage.Params.tagLine
+                                "linkedinUrl" $orgPage.Params.linkedinUrl
+                                "xUrl" $orgPage.Params.xUrl
+                                "companyUrl" $orgPage.Params.company
+                                )
+                            }}
+                        </li>
+                    {{ end }}
+                {{ end }}
+                </menu>
+                </br>
+                </br>
+                <h1 class="heading heading--3">Sponsorship Chairs</h1>
+                <menu class="speaker-list__menu">
+                {{ range $id := $data.Sponsorship }}
+                    {{ $organizer := index $itemMap $id }}
+                    {{ $orgPage := index $pageMap $id }}
+                    {{ if $organizer }}
+                        <li class="speaker-list__item">
+                            {{- partial "organizer-card.html" (
+                                dict
+                                "profileUrl" $orgPage.RelPermalink
+                                "avatarResource" ($orgPage.Resources.GetMatch "avatar.*")
+                                "name" $orgPage.Title
+                                "description" $orgPage.Params.tagLine
+                                "linkedinUrl" $orgPage.Params.linkedinUrl
+                                "xUrl" $orgPage.Params.xUrl
+                                "companyUrl" $orgPage.Params.company
+                                )
+                            }}
+                        </li>
+                    {{ end }}
+                {{ end }}
+                </menu>
+                </br>
+                </br>
+                <h1 class="heading heading--3">Doctoral Consortium Chairs</h1>
+                <menu class="speaker-list__menu">
+                {{ range $id := $data.DoctoralConsortium }}
+                    {{ $organizer := index $itemMap $id }}
+                    {{ $orgPage := index $pageMap $id }}
+                    {{ if $organizer }}
+                        <li class="speaker-list__item">
+                            {{- partial "organizer-card.html" (
+                                dict
+                                "profileUrl" $orgPage.RelPermalink
+                                "avatarResource" ($orgPage.Resources.GetMatch "avatar.*")
+                                "name" $orgPage.Title
+                                "description" $orgPage.Params.tagLine
+                                "linkedinUrl" $orgPage.Params.linkedinUrl
+                                "xUrl" $orgPage.Params.xUrl
+                                "companyUrl" $orgPage.Params.company
+                                )
+                            }}
+                        </li>
+                    {{ end }}
+                {{ end }}
+                </menu>
+            {{- end }}
+        </div>
+    </section>
+
+    {{- partial "sections/cta.html" (
+        dict
+        "eventbriteId" .Site.Params.themes.event.callToAction.eventbrite.eventId
+        "ctaUrl" .Site.Params.themes.event.callToAction.other.url
+        )
+    }}
+{{ end }}

--- a/layouts/organizers/single.html
+++ b/layouts/organizers/single.html
@@ -1,0 +1,73 @@
+{{ define "main" }}
+    <div class="section-container">
+        {{ $ariaLabel := T "speakers_page.social_links" page.Title }}
+        <section class="section single-speaker-section">
+            <div class="single-speaker-section__avatar">
+
+                {{- partial "speaker-avatar.html" (
+                    dict
+                    "avatarResource" (.Resources.GetMatch "avatar.*")
+                    "avatarAlt" page.Title
+                    "linkedinUrl" page.Params.linkedinUrl
+                    "xUrl" page.Params.xUrl
+                    "companyUrl" page.Params.company
+                    "ariaLabel" $ariaLabel
+                    )
+                }}
+            </div>
+
+            <div class="single-speaker-section__biography">
+                {{- partial "speaker-biography.html" (
+                    dict
+                    "speakerName" page.Title
+                    "speakerSlogan" page.Params.tagLine
+                    "speakerBiography" page.RawContent
+                    )
+                }}
+            </div>
+        </section>
+
+
+        {{/*
+
+        {{- $speakerSessions := slice }}
+        {{ range where .Site.RegularPages "Section" "sessions" }}
+            {{ if in .Params.speakerIds page.Params.organizerId }}
+                {{- $speakerSessions = $speakerSessions | append (
+                    dict
+                    "title" .Title
+                    "track" .Params.track
+                    "startsAt" .Params.startsAt
+                    "room" .Params.room.name
+                    "sessionUrl" .RelPermalink
+                    )
+                }}
+            {{ end }}
+        {{ end }}
+
+
+        <div class="section-container section-container--dimmed">
+            <section class="section speaker-sessions-section">
+                <h1 class="h1 speaker-sessions-section__heading">
+                    {{- T "speaker_page.sessions_by" | upper }}
+                    <span class="speaker-sessions-section__hashtag">
+                        {{- partial "elements/hashtag.html" (dict "hashtag" page.Title) }}
+                    </span>
+                </h1>
+                {{- partial "sessions-menu.html" (
+                    dict
+                    "title" page.Title
+                    "sessions" $speakerSessions
+                    )
+                }}
+            </section>
+        </div>
+*/}}
+        {{- partial "sections/cta.html" (
+            dict
+            "eventbriteId" .Site.Params.themes.event.callToAction.eventbrite.eventId
+            "ctaUrl" .Site.Params.themes.event.callToAction.other.url
+            )
+        }}
+    </div>
+{{ end }}

--- a/layouts/partials/content-adapters/create-organizers-content.html
+++ b/layouts/partials/content-adapters/create-organizers-content.html
@@ -1,0 +1,50 @@
+{{ $input := . }}
+{{ $pages := slice }}
+{{ $resources := slice }}
+
+{{ range $input.sessionize.organizers }}
+    {{ $content := dict "mediaType" "text/markdown" "value" .bio }}
+    {{ $xUrl := (index (where .links "linkType" "eq" "Twitter") 0).url }}
+    {{ $linkedinUrl := (index (where .links "linkType" "eq" "LinkedIn") 0).url }}
+    {{ $companyUrl := (index (where .links "linkType" "eq" "Company_Website") 0).url }}
+
+    {{ $params :=
+        dict
+        "organizerId" .id
+        "tagLine" .tagLine
+        "xUrl" $xUrl
+        "linkedinUrl" $linkedinUrl
+        "companyUrl" $companyUrl
+        "lastName" .lastName
+        "firstName" .firstName
+    }}
+
+    {{ $path := (printf "%s %s" .fullName .id) }}
+    {{ $page := dict
+        "content" $content
+        "kind" "page"
+        "params" $params
+        "path" $path
+        "title" .fullName
+    }}
+    {{ $pages = $pages | append $page }}
+
+    {{/* Store the organizer's profile picture. */}}
+    {{ $item := . }}
+    {{ with $url := $item.profilePicture }}
+        {{ with resources.Get $url }}
+            {{ $content := dict "mediaType" .MediaType.Type "value" .Content }}
+            {{ $params := dict "alt" $item.fullName }}
+            {{ $resource := dict
+                "content" $content
+                "params" $params
+                "path" (printf "%s/avatar.%s" $path .MediaType.SubType)
+            }}
+            {{ $resources = $resources | append $resource }}
+        {{ else }}
+            {{ errorf "Unable to get resource %s" $url }}
+        {{ end }}
+    {{ end }}
+{{ end }}
+
+{{ return dict "pages" $pages "resources" $resources }}

--- a/layouts/partials/organizer-card.html
+++ b/layouts/partials/organizer-card.html
@@ -1,0 +1,28 @@
+{{ $input := . }}
+
+
+<div class="organizer-card">
+    <a class="organizer-card__link" href="{{ $input.profileUrl }}" aria-label="{{ $input.name }}">
+        {{ with $input.avatarResource }}
+            {{ with . | images.Filter (images.Process "resize 256x") }}
+                <img
+                    class="organizer-card__avatar"
+                    src="{{ .RelPermalink }}"
+                    alt="{{ $input.name }}"
+                    width="{{ .Width }}"
+                    height="{{ .Height }}" />
+            {{- end }}
+        {{- else }}
+            {{- with resources.Get "images/shaped-image-fallback.webp" }}
+                <img
+                    class="organizer-card__avatar"
+                    src="{{ .RelPermalink }}"
+                    alt="{{ $input.name }}"
+                    width="{{ .Width }}"
+                    height="{{ .Height }}" />
+            {{- end }}
+        {{- end }}
+        <h1 class="heading">{{ $input.name }}</h1>
+        <p class="organizer-card__description">{{ $input.description }}</p>
+    </a>
+</div>

--- a/layouts/partials/organizers-all.html
+++ b/layouts/partials/organizers-all.html
@@ -1,0 +1,10 @@
+{{ $data := dict }}
+
+{{ $path := "organizers.json" }}
+{{ with resources.Get $path }}
+    {{ $data = . | transform.Unmarshal }}
+{{ else }}
+    {{ warnf "Unable to get data resource %q." $path }}
+{{ end }}
+
+{{ return $data }}


### PR DESCRIPTION
Add:
- organizer json template.
- content adapter for organizer json.
- menu entry for organizer page.

Copy speaker-card resources for organizer page.
Reuse list and single html from speaker for organizer.

`assets/organizers.json` can be modified for testing as follows:
```
-    "Website": [],
+    "Website": [
+        "felix_dollack"
+    ],
     "FinanceAndLocal": [],
     "Awards": [],
     "Sponsorship": [],
     "DoctoralConsortium": [],
-    "organizers": []
+    "organizers": [
+        {
            "id": "felix_dollack",
            "firstName": "Felix",
            "lastName": "Dollack",
            "bio": "Felix Dollack is ...",
            "tagLine": "Professional developer",
            "profilePicture": "images/kyoto.webp",
            "links": [],
            "fullName": "Felix Dollack",
            "categoryItems": []
        }
```